### PR TITLE
[実装] Unity拡張に対応するためテストをカテゴリ分け

### DIFF
--- a/Assets/Tests/Editor/Test_Station01.cs
+++ b/Assets/Tests/Editor/Test_Station01.cs
@@ -5,6 +5,7 @@ namespace Tests
     public class Station01
     {
         [Test]
+        [Category("Station01")]
         public void Test()
         {
             Assert.That(true);

--- a/Assets/Tests/Editor/Test_Station02.cs
+++ b/Assets/Tests/Editor/Test_Station02.cs
@@ -8,6 +8,7 @@ namespace Tests
     public class Station02
     {
         [UnityTest]
+        [Category("Station02")]
         public IEnumerator Test()
         {
             yield return TestUtility.LoadScene();

--- a/Assets/Tests/Editor/Test_Station03.cs
+++ b/Assets/Tests/Editor/Test_Station03.cs
@@ -8,6 +8,7 @@ namespace Tests
     public class Station03
     {
         [UnityTest]
+        [Category("Station03")]
         public IEnumerator Test()
         {
             yield return TestUtility.LoadScene();

--- a/Assets/Tests/Editor/Test_Station04.cs
+++ b/Assets/Tests/Editor/Test_Station04.cs
@@ -8,6 +8,7 @@ namespace Tests
     public class Station04
     {
         [UnityTest]
+        [Category("Station04")]
         public IEnumerator Test()
         {
             yield return TestUtility.LoadScene();

--- a/Assets/Tests/Editor/Test_Station05.cs
+++ b/Assets/Tests/Editor/Test_Station05.cs
@@ -8,6 +8,7 @@ namespace Tests
     public class Station05
     {
         [UnityTest]
+        [Category("Station05")]
         public IEnumerator Test()
         {
             yield return TestUtility.LoadScene();

--- a/Assets/Tests/Editor/Test_Station06.cs
+++ b/Assets/Tests/Editor/Test_Station06.cs
@@ -9,6 +9,7 @@ namespace Tests
     public class Station06
     {
         [UnityTest]
+        [Category("Station06")]
         public IEnumerator Test()
         {
             yield return TestUtility.LoadScene();

--- a/Assets/Tests/Editor/Test_Station07.cs
+++ b/Assets/Tests/Editor/Test_Station07.cs
@@ -9,6 +9,7 @@ namespace Tests
     public class Station07
     {
         [UnityTest]
+        [Category("Station07")]
         public IEnumerator Test()
         {
             yield return TestUtility.LoadScene();

--- a/Assets/Tests/Editor/Test_Station08.cs
+++ b/Assets/Tests/Editor/Test_Station08.cs
@@ -9,6 +9,7 @@ namespace Tests
     public class Station08
     {
         [UnityTest]
+        [Category("Station08")]
         public IEnumerator Test()
         {
             yield return TestUtility.LoadScene();

--- a/Assets/Tests/Editor/Test_Station09.cs
+++ b/Assets/Tests/Editor/Test_Station09.cs
@@ -10,6 +10,7 @@ namespace Tests
     public class Station09
     {
         [UnityTest]
+        [Category("Station09")]
         public IEnumerator Test()
         {
             yield return TestUtility.LoadScene();

--- a/Assets/Tests/Editor/Test_Station10.cs
+++ b/Assets/Tests/Editor/Test_Station10.cs
@@ -11,6 +11,7 @@ namespace Tests
     public class Station10
     {
         [UnityTest]
+        [Category("Station10")]
         public IEnumerator Test()
         {
             yield return TestUtility.LoadScene();

--- a/Assets/Tests/Editor/Test_Station11.cs
+++ b/Assets/Tests/Editor/Test_Station11.cs
@@ -11,6 +11,7 @@ namespace Tests
     public class Station11
     {
         [UnityTest]
+        [Category("Station11")]
         public IEnumerator Test()
         {
             yield return TestUtility.LoadScene();


### PR DESCRIPTION
- Unity拡張はテストケースをCategory単位で識別するため各テストにCategoryアノテーションを追加
