### PR TITLE
chore: update techtrain-unity-extension to v1.1.0

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -6,7 +6,7 @@
     "com.unity.timeline": "1.7.6",
     "com.unity.ugui": "1.0.0",
     "com.unity.visualscripting": "1.9.4",
-    "dev.techtrain.techtrain-unity-extension": "https://github.com/TechBowl-japan/techtrain-unity-extension.git?path=/Assets/_techtrain#v1.0.0",
+    "dev.techtrain.techtrain-unity-extension": "https://github.com/TechBowl-japan/techtrain-unity-extension.git?path=/Assets/_techtrain#v1.1.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",


### PR DESCRIPTION
## Summary

- `techtrain-unity-extension` のパッケージ参照を `v1.0.0` → `v1.1.0` に更新
- 有料プラン制限の削除に伴うバージョン追従（[techtrain-unity-extension PR #26](https://github.com/TechBowl-japan/techtrain-unity-extension/pull/26)）

## Changes

- `Packages/manifest.json`: パッケージ参照タグを `#v1.0.0` → `#v1.1.0` に変更

## Note

この PR は techtrain-unity-extension リポジトリで v1.1.0 タグが作成された後にマージしてください。